### PR TITLE
Abhishek Sharma - Fixed failing test cases for immutability of Student class and serialization validation for Adult class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.assertj:assertj-core:3.25.3'
-	testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/apptware/interview/immutability/Student.java
+++ b/src/main/java/com/apptware/interview/immutability/Student.java
@@ -1,15 +1,31 @@
 /** This class is expected to be immutable. Please make necessary changes. */
 package com.apptware.interview.immutability;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
-@Getter
-@AllArgsConstructor
 public class Student {
-  private String name;
-  private Date dateOfBirth;
-  private List<String> courses;
+  private final String name;
+  private final Date dateOfBirth;
+  private final List<String> courses;
+
+  public Student(String name, Date dateOfBirth, List<String> courses) {
+    this.name = name;
+    this.dateOfBirth = new Date(dateOfBirth.getTime());
+    this.courses = Collections.unmodifiableList(courses);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Date getDateOfBirth() {
+    return new Date(dateOfBirth.getTime());
+  }
+
+  public List<String> getCourses() {
+    return new ArrayList<>(courses);
+  }
 }

--- a/src/main/java/com/apptware/interview/serialization/Adult.java
+++ b/src/main/java/com/apptware/interview/serialization/Adult.java
@@ -1,12 +1,15 @@
 package com.apptware.interview.serialization;
 
-import java.util.Objects;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Objects;
+
 @Data
 @NoArgsConstructor
+@JsonDeserialize(using = AdultDeserializer.class)
 public class Adult {
 
   private String firstName;

--- a/src/main/java/com/apptware/interview/serialization/AdultDeserializer.java
+++ b/src/main/java/com/apptware/interview/serialization/AdultDeserializer.java
@@ -1,0 +1,27 @@
+package com.apptware.interview.serialization;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+
+class AdultDeserializer extends JsonDeserializer<String> {
+    @Override
+    public String deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        ObjectNode node = p.readValueAsTree();
+        boolean isFirstNameBlank = StringUtils.isBlank(node.get("firstName").asText());
+        boolean isLastNameBlank = StringUtils.isBlank(node.get("lastName").asText());
+
+        if (isFirstNameBlank || isLastNameBlank) {
+            throw new IllegalArgumentException("Firstname or Lastname CANNOT be blank.");
+        }
+
+        if (node.get("age").asInt() < 18) {
+            throw new IllegalArgumentException("Inappropriate Age for an Adult.");
+        }
+        return p.getValueAsString();
+    }
+}

--- a/src/test/java/com/apptware/interview/serialization/AdultTest.java
+++ b/src/test/java/com/apptware/interview/serialization/AdultTest.java
@@ -16,14 +16,12 @@ class AdultTest {
 
   @Test
   void testConstructorValidation() {
-    Assertions.assertThatThrownBy(() -> new Adult("", "", 18))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Firstname or Lastname CANNOT be blank.");
-    Assertions.assertThatThrownBy(() -> new Adult("Firstname", "Lastname", 17))
-        .isInstanceOf(IllegalArgumentException.class)
-    // Changes expected ----->
-        .hasMessage("Firstname or Lastname CANNOT be blank.");
-    // <----- Changes expected
+      Assertions.assertThatThrownBy(() -> new Adult("", "", 18))
+              .isInstanceOf(IllegalArgumentException.class)
+              .hasMessage("Firstname or Lastname CANNOT be blank.");
+      Assertions.assertThatThrownBy(() -> new Adult("Firstname", "Lastname", 17))
+              .isInstanceOf(IllegalArgumentException.class)
+              .hasMessage("Inappropriate Age for an Adult.");
 
     String json1 =
         """
@@ -43,24 +41,20 @@ class AdultTest {
             }
             """;
 
-    ObjectMapper objectMapper = new ObjectMapper();
-    Assertions.assertThatThrownBy(
-            () -> {
-              Adult adult = objectMapper.readValue(json1, Adult.class);
-              System.out.println(adult);
-            })
-    // Changes expected ----->
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Firstname or Lastname CANNOT be blank.");
-    // <----- Changes expected
-    Assertions.assertThatThrownBy(
-            () -> {
-              Adult adult = objectMapper.readValue(json2, Adult.class);
-              System.out.println(adult);
-            })
-    // Changes expected ----->
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Inappropriate Age for an Adult.");
-    // <----- Changes expected
+      ObjectMapper objectMapper = new ObjectMapper();
+
+      Assertions.assertThatThrownBy( () -> {
+                  Adult adult = objectMapper.readValue(json1, Adult.class);
+                  System.out.println(adult);
+              })
+              .isInstanceOf(IllegalArgumentException.class)
+              .hasMessage("Firstname or Lastname CANNOT be blank.");
+
+      Assertions.assertThatThrownBy( () -> {
+                  Adult adult = objectMapper.readValue(json2, Adult.class);
+                  System.out.println(adult);
+              })
+              .isInstanceOf(IllegalArgumentException.class)
+              .hasMessage("Inappropriate Age for an Adult.");
   }
 }


### PR DESCRIPTION
- To fix the first test case for Student class:

  1. Marked fields as final to prevent reassignment.
  2. Modified the constructor to create defensive copies of mutable fields Date and List.
  3. Adjusted getter methods to return defensive copies of mutable fields.
  4. Used Collections.unmodifiableList() to make the list of courses immutable.

- To fix the second test case for Adult class:

  1. Added a new AdultDeserializer class to handle the deserialization of Adult objects.
  2. The AdultDeserializer class extends JsonDeserializer and overrides the deserialize method to customize the 
deserialization process.
  3. Implemented logic in the deserialize method to check if the firstName or lastName fields are blank, throwing an IllegalArgumentException if either is blank.
  4. Also added logic to check if the age field is less than 18, throwing an IllegalArgumentException if the age is inappropriate for an adult.
  5. Modified the Adult class to use the AdultDeserializer for deserialization by annotating it with @JsonDeserialize(using = AdultDeserializer.class).
  6. Adjusted the AdultTest class to fix the serialization test cases, ensuring they properly throw exceptions with appropriate messages during deserialization.