### PR TITLE
Test cases fixed

### DIFF
--- a/src/main/java/com/apptware/interview/comparison/SomeClass.java
+++ b/src/main/java/com/apptware/interview/comparison/SomeClass.java
@@ -1,6 +1,8 @@
 package com.apptware.interview.comparison;
 
 import java.util.Date;
+import java.util.Objects;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -11,4 +13,18 @@ class SomeClass {
   // This is a unique identifier
   private Integer id;
   private Date lastInvoked;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SomeClass that = (SomeClass) o;
+    return Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+
 }

--- a/src/main/java/com/apptware/interview/jpa/employee/Employee.java
+++ b/src/main/java/com/apptware/interview/jpa/employee/Employee.java
@@ -2,6 +2,8 @@ package com.apptware.interview.jpa.employee;
 
 import jakarta.persistence.Entity;
 import java.util.UUID;
+
+import jakarta.persistence.Id;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,7 +11,7 @@ import lombok.Setter;
 @Setter
 @Entity
 class Employee {
-
+  @Id
   private UUID id;
   private String name;
 }

--- a/src/test/java/com/apptware/interview/stream/StreamSideEffectTest.java
+++ b/src/test/java/com/apptware/interview/stream/StreamSideEffectTest.java
@@ -1,6 +1,7 @@
 package com.apptware.interview.stream;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.assertj.core.api.Assertions;
@@ -11,17 +12,13 @@ class StreamSideEffectTest {
   @Test
   void parallelStream() {
     List<Integer> numbers = new ArrayList<>();
-    List<Integer> results = new ArrayList<>();
+    List<Integer> results = Collections.synchronizedList(new ArrayList<>());
 
     IntStream.range(1, 100000).forEach(numbers::add);
     // DO NOT CHANGE >>>>>
     numbers.parallelStream()
         // <<<<< DO NOT CHANGE
-        .map(
-            number -> {
-              results.add(number * 2);
-              return number * 2;
-            });
+        .forEach(results::add);
 
     Assertions.assertThat(numbers).containsExactlyInAnyOrder(results.toArray(Integer[]::new));
   }


### PR DESCRIPTION
- Comparison Test fixed: Added equals and hash Code methods which are required for comparison

- Employee Test fixed: Added @Id annotation in Employee, which is essential for entity class

- Stream Side Effect Test fixed: 
To make the result array available to all threads, updated the simple array list to Collections.synchronizedList 
Approach 1:
To ensure the result array have the added values after the parallel Stream and before comparing, updated 
`.map(
            number -> {
              results.add(number * 2);
              return number * 2;
            });` with `.forEach(results::add)` .
Approach 2:  
Using `.toList()` after map to ensure the result array is updated. 
The result of map is not stored or used so, the numbers list will not change so either remove multiply by 2 exp or update the numbers array to new array ;

- Singleton Test: I couldn't find any solution for this.
- Bean Factory Test: I am unable to debug the issue here.