### PR TITLE
changes in DataReaderImpl.java

### DIFF
--- a/src/main/java/com/apptware/interview/stream/impl/DataReaderImpl.java
+++ b/src/main/java/com/apptware/interview/stream/impl/DataReaderImpl.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -33,9 +34,18 @@ class DataReaderImpl implements DataReader {
 
     // Placeholder for paginated data fetching logic
     // The candidate will add the actual implementation here
+    int pageSize = 100; 
+    int page = 1;
+    List<String> paginatedData;
 
-    Stream<String> dataStream =
-        Stream.empty(); // Temporary, will be replaced by the actual data stream
-    return dataStream.peek(item -> log.info("Fetched Item: {}", item));
+  
+    Stream<String> dataStream = Stream.iterate(page, p -> p + 1)
+        .map(p -> paginationService.getPaginatedData(p, pageSize)) 
+        .takeWhile(data -> !data.isEmpty()) 
+        .flatMap(List::stream) 
+        .peek(item -> log.info("Fetched Item: {}", item)); 
+
+    return dataStream;
+
   }
 }


### PR DESCRIPTION
Implement streaming of paginated data in DataReaderImpl

Added the fetchPaginatedDataAsStream() method to the DataReaderImpl class. 
This method utilizes the PaginationService to retrieve data in pages and 
stream it to consumers. The implementation uses an infinite stream with 
takeWhile to stop fetching when no more data is available, allowing for 
efficient data handling.

Also added logging for each fetched item to facilitate monitoring 
of the data retrieval process.
