### PR TITLE
fix failing tests and improve pagination logic

### DIFF
--- a/src/main/java/com/apptware/interview/stream/impl/DataReaderImpl.java
+++ b/src/main/java/com/apptware/interview/stream/impl/DataReaderImpl.java
@@ -3,8 +3,13 @@ package com.apptware.interview.stream.impl;
 import com.apptware.interview.stream.DataReader;
 import com.apptware.interview.stream.PaginationService;
 import jakarta.annotation.Nonnull;
+
 import java.util.stream.Stream;
+import java.util.List;
+
 import lombok.extern.slf4j.Slf4j;
+
+//import org.glassfish.jaxb.runtime.v2.schemagen.xmlschema.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -12,7 +17,8 @@ import org.springframework.stereotype.Service;
 @Service
 class DataReaderImpl implements DataReader {
 
-  @Autowired private PaginationService paginationService;
+  @Autowired
+  private PaginationService paginationService;
 
   @Override
   public Stream<String> fetchLimitadData(int limit) {
@@ -25,17 +31,27 @@ class DataReaderImpl implements DataReader {
   }
 
   /**
-   * This method is where the candidate should add the implementation. Logs have been added to track
+   * This method is where the candidate should add the implementation. Logs have
+   * been added to track
    * the data fetching behavior. Do not modify any other areas of the code.
    */
   private @Nonnull Stream<String> fetchPaginatedDataAsStream() {
-    log.info("Fetching paginated data as stream.");
+    log.info("Fetching paginated data as a stream.");
 
-    // Placeholder for paginated data fetching logic
-    // The candidate will add the actual implementation here
+    int pageSize = 100; // Number of items per page
+    int totalPages = (int) Math.ceil((double) PaginationService.FULL_DATA_SIZE / pageSize); // Calculate total pages
+                                                                                            // based on FULL_DATA_SIZE
 
-    Stream<String> dataStream =
-        Stream.empty(); // Temporary, will be replaced by the actual data stream
-    return dataStream.peek(item -> log.info("Fetched Item: {}", item));
+    // Use Stream.iterate() to generate a stream of pages (1-based index) and
+    // flatMap to the data items
+    return Stream.iterate(1, page -> page <= totalPages, page -> page + 1)
+        .flatMap(page -> {
+          log.info("Fetching data for page {}", page);
+          List<String> pageData = paginationService.getPaginatedData(page, pageSize); // Get data for the current page
+          log.info("Page {} contains {} items", page, pageData.size());
+          return pageData.stream(); // Convert page data to a stream of items
+        })
+        .peek(item -> log.info("Fetched Item: {}", item)); // Log each item fetched
   }
+
 }


### PR DESCRIPTION
**Purpose**:
To fetch a large dataset in chunks (pagination) and provide it as a continuous stream of items, ensuring efficient memory usage.

How It Works:
1. **Logging Start**:

-  A log statement is added at the beginning to indicate the start of the streaming process.

2.**Pagination Setup**:

- pageSize: Defines the number of items fetched in each page (set to 100).

- totalPages: Calculates the total number of pages based on the FULL_DATA_SIZE and the pageSize.

3.**Stream Construction**:

- A Stream.iterate is used to generate a stream of page numbers starting from 1 up to the totalPages.

- The lambda (page -> page <= totalPages) ensures that only valid page numbers are processed.

- The increment (page -> page + 1) advances the page number in each iteration.

4.**Fetching and Streaming Data**:

- For each page, a call is made to paginationService.getPaginatedData(page, pageSize) to retrieve a list of items for that page.

- The data is then converted into a stream (pageData.stream()), allowing seamless processing of items.

5.**Logging During Fetch**:

- Logs the number of items fetched and the page number for debugging and monitoring.

6.**tem Logging with Peek**:

- Uses .peek() to log individual items as they pass through the stream for detailed tracking.

7.**Return Statement**:

- Returns a continuous stream of all items fetched from the paginated service.